### PR TITLE
Catch IllegalFormatConversionException and throw with more info

### DIFF
--- a/src/com/gfredericks/like_format_but_with_named_args.clj
+++ b/src/com/gfredericks/like_format_but_with_named_args.clj
@@ -52,10 +52,11 @@
                    ;; passing it through format just in case we need to do a
                    ;; "%%" -> "%" conversion.
                    (format clojure-format-string)
-                   `(let [arg-map# ~arg-map]
-                      (try (apply format ~clojure-format-string (map #(get arg-map# %) ~names))
+                   `(let [arg-map# ~arg-map
+                          clojure-format-string# ~clojure-format-string]
+                      (try (apply format clojure-format-string# (map #(get arg-map# %) ~names))
                            (catch java.util.IllegalFormatConversionException e#
-                             (throw-on-bad-format ~clojure-format-string arg-map# e#))))))
+                             (throw-on-bad-format clojure-format-string# arg-map# e#))))))
                `(let [[clojure-format-string# names#] (parse-named-format-string ~format-string)
                       arg-map# ~arg-map]
                   (try (apply format clojure-format-string# (map #(get arg-map# %) names#))

--- a/src/com/gfredericks/like_format_but_with_named_args.clj
+++ b/src/com/gfredericks/like_format_but_with_named_args.clj
@@ -27,7 +27,7 @@
 
   (throw (ex-info "Bad call to named-format" {:format-string format-string
                                               :arg-map    arg-map}
-                  (.getMessage e))))
+                  e)))
 
 (defn named-format
   "Like clojure.core/format but uses named args. `format-string` is

--- a/src/com/gfredericks/like_format_but_with_named_args.clj
+++ b/src/com/gfredericks/like_format_but_with_named_args.clj
@@ -25,9 +25,9 @@
 (defn throw-on-bad-format
   [format-string arg-map e]
 
-  (throw (ex-info "Unable to use named-format!" {:format-string format-string
-                                                 :arg-map       arg-map
-                                                 :cause         (.getMessage e)})))
+  (throw (ex-info "Bad call to named-format" {:format-string format-string
+                                              :arg-map    arg-map}
+                  (.getMessage e))))
 
 (defn named-format
   "Like clojure.core/format but uses named args. `format-string` is

--- a/test/com/gfredericks/like_format_but_with_named_args_test.clj
+++ b/test/com/gfredericks/like_format_but_with_named_args_test.clj
@@ -15,3 +15,23 @@
        "I can also put a number in like %num~.3f."
        {:num 3.14159}
        "I can also put a number in like 3.142."))
+
+(deftest bad-call-test
+  (are [s m error-str] (= {:format-string error-str :arg-map m}
+                          (try (named-format s m)
+                               (catch Exception e (ex-data e))))
+    "...Toss %me~d."
+    {:me "not a number"}
+    "...Toss %d."
+
+    "%what~o?"
+    {:what "not an octal"}
+    "%o?"
+
+    "I cannot format the %string~s. You'll have to toss %me~d."
+    {:string "an actual string" :me :still-not-a-number}
+    "I cannot format the %s. You'll have to toss %d."
+
+    "...Don't tell the %runtime~f."
+    {:runtime 1} ;; Not a float
+    "...Don't tell the %f."))


### PR DESCRIPTION
Resolves #1 

Well, here's an attempt... the inlining makes things very messy. I stared at this for a while wondering if defining the function outside of the macro would ruin the inline optimization or not. I'm still not sure and it was hurting my brain so I decided to just hand this over as is. 

Does this work? Do I actually have to re-implement throw-on-bad-format in three places? If so, why? 